### PR TITLE
Fix order of :< and :> in Control.Lens.Cons

### DIFF
--- a/src/Control/Lens/Cons.hs
+++ b/src/Control/Lens/Cons.hs
@@ -30,7 +30,7 @@ module Control.Lens.Cons
   , uncons
   , _head, _tail
 #if __GLASGOW_HASKELL__ >= 710
-  , pattern (:>)
+  , pattern (:<)
 #endif
   -- * Snoc
   , Snoc(..)
@@ -39,7 +39,7 @@ module Control.Lens.Cons
   , unsnoc
   , _init, _last
 #if __GLASGOW_HASKELL__ >= 710
-  , pattern (:<)
+  , pattern (:>)
 #endif
 
   ) where


### PR DESCRIPTION
The order of these patterns in the docs seems wrong - the Snoc one is after the Cons functions and the Cons one is after the Snoc functions.